### PR TITLE
Refactor CLI interface for simplicity at the entry point

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,9 @@
 use std::{env, process::exit};
 
-const ALLOWED_FLAGS: [&str; 4] = ["-b", "-w", "-s", "-h"];
+use crate::reg;
+use crate::path;
+
+const ALLOWED_FLAGS: [&'static str; 4] = ["-b", "-w", "-s", "-h"];
 
 /// Parses command line arguments
 pub fn parse_command_line_flags() -> Vec<String> {
@@ -16,4 +19,26 @@ pub fn parse_command_line_flags() -> Vec<String> {
         }
     }
     args
+}
+
+// Interpret command line flags passed at runtime
+pub fn interpret_command_line_flags(
+    cli_flags: &Vec<String>, 
+    reg_type: &mut Option<reg::RegistryType>, 
+    print_type: &mut Option<path::PrintType>
+) {
+    for flag in cli_flags {
+        match flag.as_str() {
+            "-b" => {
+                *print_type = Some(path::PrintType::Base);
+            },
+            "-s" => {
+                *reg_type = Some(reg::RegistryType::Sys);
+            },
+            _ => {
+                *print_type = Some(path::PrintType::Cleaned);
+                *reg_type = Some(reg::RegistryType::User)
+            }
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,25 +3,22 @@ mod path;
 mod reg;
 
 fn main() {
+    // Parse command line flags
     let cli_flags = cli::parse_command_line_flags();
 
-    let print_type = if cli_flags.contains(&String::from("-b")) {
-        path::PrintType::Base
-    } else {
-        path::PrintType::Cleaned
-    };
+    // Interpret command line flags to runtime options
+    let mut reg_type: Option<reg::RegistryType> = None;
+    let mut print_type: Option<path::PrintType> = None;
+    cli::interpret_command_line_flags(&cli_flags, &mut reg_type, &mut print_type);
 
-    let reg_type = if cli_flags.contains(&String::from("-s")) {
-        reg::RegistryType::Sys
-    } else {
-        reg::RegistryType::User
-    };
+    // Initialize path struct with options
+    let mut path = path::PathEnvVar::new(print_type.unwrap(), reg_type.unwrap());
 
-    let mut path = path::PathEnvVar::new(print_type, reg_type);
-
+    // Print and validate
     path.print();
     path.validate();
 
+    // Optionally; write a cleaned path when `-w` flag passed
     if cli_flags.contains(&String::from("-w")) {
         path.write_clean_path();
     }

--- a/src/reg.rs
+++ b/src/reg.rs
@@ -3,8 +3,8 @@ use winreg::enums::HKEY_LOCAL_MACHINE;
 use winreg::enums::KEY_ALL_ACCESS;
 use winreg::RegKey;
 
-const SYSTEM_KEY: &str = "SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
-const USER_KEY: &str = "Environment";
+const SYSTEM_KEY: &'static str = "SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment";
+const USER_KEY: &'static str = "Environment";
 
 /// Registry type can be either User or Sys, indicating whether to reference
 /// the system or user level environment variables


### PR DESCRIPTION
Moves a chunk of logic from the `main` function to the CLI module, for readability. Also avoids 2 unnecessary String allocations. 